### PR TITLE
Handle job parameter for credentials

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -28,6 +28,7 @@ var (
 
 type collector struct {
 	target string
+	job    string
 	config *SafeConfig
 }
 
@@ -455,7 +456,7 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 		)
 	}()
 
-	creds, err := c.config.CredentialsForTarget(c.target)
+	creds, err := c.config.CredentialsForTarget(c.target, c.job)
 	if err != nil {
 		log.Errorf("No credentials available for target %s.", c.target)
 		c.markAsDown(ch)

--- a/collector.go
+++ b/collector.go
@@ -456,9 +456,9 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 		)
 	}()
 
-	creds, err := c.config.CredentialsForTarget(c.target, c.job)
+	creds, err := c.config.CredentialsForJob(c.job)
 	if err != nil {
-		log.Errorf("No credentials available for target %s.", c.target)
+		log.Errorf("No credentials available for job %s.", c.job)
 		c.markAsDown(ch)
 		return
 	}

--- a/config.go
+++ b/config.go
@@ -113,9 +113,9 @@ func (sc *SafeConfig) ReloadConfig(configFile string) error {
 		if sc.C.Credentials == nil {
 			sc.C.Credentials = make(map[string]Credentials)
 		}
-		c.Credentials["netbox/cp"] = Credentials{User: netboxCPUser, Password: netboxCPPassword}
+		c.Credentials["cp/netbox"] = Credentials{User: netboxCPUser, Password: netboxCPPassword}
 
-		log.Infoln("Found netbox/cp user env")
+		log.Infoln("Found cp/netbox user env")
 	}
 
 	log.Infoln("Loaded config file")

--- a/config.go
+++ b/config.go
@@ -122,17 +122,11 @@ func (sc *SafeConfig) ReloadConfig(configFile string) error {
 	return nil
 }
 
-// CredentialsForTarget returns the Credentials for a given target, or the
+// CredentialsForJob returns the Credentials for a given job, or the
 // default. It is concurrency-safe.
-func (sc *SafeConfig) CredentialsForTarget(target string, job string) (Credentials, error) {
+func (sc *SafeConfig) CredentialsForJob(job string) (Credentials, error) {
 	sc.Lock()
 	defer sc.Unlock()
-	if credentials, ok := sc.C.Credentials[target]; ok {
-		return Credentials{
-			User:     credentials.User,
-			Password: credentials.Password,
-		}, nil
-	}
 	if credentials, ok := sc.C.Credentials[job]; ok {
 		return Credentials{
 			User:     credentials.User,
@@ -145,7 +139,7 @@ func (sc *SafeConfig) CredentialsForTarget(target string, job string) (Credentia
 			Password: credentials.Password,
 		}, nil
 	}
-	return Credentials{}, fmt.Errorf("no credentials found for target %s", target)
+	return Credentials{}, fmt.Errorf("no credentials found for job %s", job)
 }
 
 // ExcludeSensorIDs returns the list of excluded sensor IDs in a

--- a/config.go
+++ b/config.go
@@ -100,11 +100,11 @@ func (sc *SafeConfig) ReloadConfig(configFile string) error {
 		if sc.C.Credentials == nil {
 			sc.C.Credentials = make(map[string]Credentials)
 		}
-		sc.C.Credentials["default"] = Credentials{
+		sc.C.Credentials["baremetal/ironic"] = Credentials{
 			User:     ipmiUser,
 			Password: ipmiPassword,
 		}
-		log.Infoln("Found ipmi user env")
+		log.Infoln("Found baremetal/ironic user env")
 	}
 
 	netboxCPUser := os.Getenv("NETBOX_CP_USER")

--- a/main.go
+++ b/main.go
@@ -40,10 +40,14 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "'target' parameter must be specified", 400)
 		return
 	}
+	job := r.URL.Query().Get("job")
+	if job == "" {
+		log.Warnf("job parameter is not specified for target: %s", target)
+	}
 	log.Debugf("Scraping target '%s'", target)
 
 	registry := prometheus.NewRegistry()
-	collector := collector{target: target, config: sc}
+	collector := collector{target: target, job: job, config: sc}
 	registry.MustRegister(collector)
 	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 	h.ServeHTTP(w, r)


### PR DESCRIPTION
With this change:

- `job` parameter for credential handling added
- `netbox/cp` environment variables handling added for its job specific credentials.

If `job` parameter is provided, exporter uses matching credentials to the job:
```
root@ipmi-exporter-i313226-7bfddcfd4d-8bpnl:/app# curl "http://localhost:9290/ipmi?target=10.*.**&job=netbox/cp"
# HELP ipmi_bmc_info Constant metric with value '1' providing details about the BMC.
# TYPE ipmi_bmc_info gauge
ipmi_bmc_info{firmware_revision="2.00",manufacturer_id="Cisco Systems, Inc. (5771)"} 1
# HELP ipmi_current_state Reported state of a current sensor (0=nominal, 1=warning, 2=critical).
# TYPE ipmi_current_state gauge
ipmi_current_state{id="43",name="PSU1_IOUT"} 0
ipmi_current_state{id="49",name="PSU2_IOUT"} 0
```

Previous approach still works as expected without job parameter:
```
root@ipmi-exporter-i313226-7bfddcfd4d-8bpnl:/app# curl "http://localhost:9290/ipmi?target=****.qa-de-1.cloud.sap"
# HELP ipmi_bmc_info Constant metric with value '1' providing details about the BMC.
# TYPE ipmi_bmc_info gauge
ipmi_bmc_info{firmware_revision="3.15",manufacturer_id="Dell Inc. (674)"} 1
...
```